### PR TITLE
Unifying the name of comments parameter

### DIFF
--- a/layouts/_default/about.html
+++ b/layouts/_default/about.html
@@ -9,7 +9,7 @@
       <h1 class="post-title">{{ .Title }}</h1>
     </header>
     <article class="post-content">{{ .Content }}</article>
-    {{ if ne .Params.comment false }}
+    {{ if ne .Params.comments false }}
       {{ if .Site.Params.changyan }}
       <div id="SOHUCS" sid="{{ .URL }}" ></div>
       <script type="text/javascript">


### PR DESCRIPTION
The parameter to enable/disable comments in about layout is different to single post layout.
about layout: .Params.comment
post layout:   .Params.comments
Probably typo?

This pull request would:
Unify the name of the comments parameter across files, namely by changing it in the about layout from .Params.comment to .Params.comments