### PR TITLE
Add / to end of tag links

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -12,7 +12,7 @@
       {{ $data := .Data }}
       {{ range $key, $value := $data.Terms.ByCount }}
         {{ $weight := $value.Count }}
-        <a href="/{{ $data.Plural }}/{{ $value.Name | urlize }}" class="tag-{{ if eq $weight 1 }}s{{ else if eq $weight 2 }}m{{ else if eq $weight 4 }}l{{ else if eq $weight 8 }}xl{{ else }}xxl{{ end }}">{{ $value.Name }}</a>
+        <a href="/{{ $data.Plural }}/{{ $value.Name | urlize }}/" class="tag-{{ if eq $weight 1 }}s{{ else if eq $weight 2 }}m{{ else if eq $weight 4 }}l{{ else if eq $weight 8 }}xl{{ else }}xxl{{ end }}">{{ $value.Name }}</a>
       {{ end }}
     </div>
   </section>


### PR DESCRIPTION
On hosters like S3 the missing `/` at the end of the link results in a redirect otherwise