### PR TITLE
Fix display math

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,7 +14,7 @@
   MathJax.Hub.Config({
     tex2jax: {
       inlineMath: [['$','$'], ['\\(','\\)']],
-      displayMath: [['$$','$$'], ['\[','\]']],
+      displayMath: [['$$','$$'], ['\\[','\\]']],
       processEscapes: true,
       processEnvironments: true,
       skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],


### PR DESCRIPTION
This fixes the rendering of display math wrapped in `\[ ... \]`.