### PR TITLE
Fix empty post list issue

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
   <header class="list-header offscreen">
     <h2 class="list-label">All Posts</h2>
   </header>
-  {{ $paginator := .Paginate (where .Data.Pages "Type" "post") (index .Site.Params "paginate" | default 10) }}
+  {{ $paginator := .Paginate (where .Site.RegularPages "Type" "post") (index .Site.Params "paginate" | default 10) }}
   {{ if ne $paginator.TotalPages 0 }}
   {{ range $paginator.Pages.ByDate.Reverse }} {{ .Render "summary" }} {{ end }}
   {{ else }}


### PR DESCRIPTION
As reported [here](https://github.com/gohugoio/hugoThemes/issues/682) index page no longer listed existing posts but link to posts.