### PR TITLE
fix: vertical-align not defined on links page

### DIFF
--- a/assets/styles/partials/_links.scss
+++ b/assets/styles/partials/_links.scss
@@ -7,6 +7,7 @@
     display: inline-block;
     width: 25%;
     box-sizing: border-box;
+    vertical-align: top;
 
     & + .link-item {
       padding-left: 1rem;


### PR DESCRIPTION
When some link items have no description set in `data/links.toml`, they cannot be displayed at the same level with other items that have a description. Applying `vertical-align: top` can fix this.