### PR TITLE
Fix warning when built with hugo version >= 0.55.0: Page's .Hugo is d…

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -81,7 +81,7 @@
 {{ end }}
 
 <!-- Site Generator -->
-<meta name="generator" content="Hugo {{ .Hugo.Version }}">
+<meta name="generator" content="Hugo {{ hugo.Version }}">
 
 <!-- Permalink & RSSlink -->
 <link rel="canonical" href="{{ .Permalink }}">


### PR DESCRIPTION
…eprecated and will be removed in a future release. Use the global hugo function.

Closes #132
